### PR TITLE
Fixed auto_play config key

### DIFF
--- a/isponsorblocktv/config.yaml
+++ b/isponsorblocktv/config.yaml
@@ -19,7 +19,7 @@ options:
   skip_count_tracking: false
   mute_ads: false
   skip_ads: true
-  autoplay: true
+  auto_play: true
 schema:
   apikey: password
   devices:
@@ -34,6 +34,6 @@ schema:
   skip_count_tracking: bool
   mute_ads: bool
   skip_ads: bool
-  autoplay: bool
+  auto_play: bool
 image: "ghcr.io/bertybuttface/{arch}-addon-isponsorblocktv"
 host_network: true


### PR DESCRIPTION
Fixes an issue with autoplay always being enabled because of some confusion over the auto_play key.

Relevant comment where I found the solution: https://github.com/dmunozv04/iSponsorBlockTV/issues/82#issuecomment-2217586517