### PR TITLE
Update iSponsorBlockTV addon to version 2.6.0

### DIFF
--- a/isponsorblocktv/CHANGELOG.md
+++ b/isponsorblocktv/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## 2.6.0
+
+- Update upstream to latest (2.6.0)
+- Maintain Raspberry Pi 4 support via aarch64 architecture
+- Enhanced compatibility and bug fixes from upstream
+
 ## 2.3.0
 
 - Update upstream to latest

--- a/isponsorblocktv/config.yaml
+++ b/isponsorblocktv/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: iSponsorBlockTV add-on
-version: "2.3.0"
+version: "2.6.0"
 slug: isponsorblocktv
 description: SponsorBlock client for all YouTube TV clients.
 url: "https://github.com/bertybuttface/addons/tree/main/isponsorblocktv"


### PR DESCRIPTION
## Summary
- Update iSponsorBlockTV addon from version 2.3.0 to 2.6.0 to match upstream
- Maintain full Raspberry Pi 4 support via existing aarch64 architecture configuration
- Include enhanced compatibility and bug fixes from upstream

## Changes Made
- Bumped version in `config.yaml` from 2.3.0 to 2.6.0
- Updated `CHANGELOG.md` with version 2.6.0 entry documenting changes

## Test Plan
- [x] Verified aarch64 architecture support for Raspberry Pi 4
- [x] Confirmed base image compatibility (`ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.21`)
- [x] Updated changelog with appropriate version documentation
- [ ] Test installation on Home Assistant instance
- [ ] Verify functionality on Raspberry Pi 4 setup

## Raspberry Pi 4 Support
This update maintains full Raspberry Pi 4 compatibility through the existing `aarch64` architecture support in the addon configuration.